### PR TITLE
Add instructions in README

### DIFF
--- a/.github/actions/local-action/package.json
+++ b/.github/actions/local-action/package.json
@@ -4,7 +4,6 @@
   "description": "Local exercise action to verify the desire commit was removed",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "build": "ncc build main.js"
   },
   "repository": {

--- a/.github/workflows/grading.yml
+++ b/.github/workflows/grading.yml
@@ -26,4 +26,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: troubleshooting steps
-        run: echo "" #Help the user to troubleshoot the activity
+        run: echo "See the following doc for helping with configuring secret scanning: https://docs.github.com/en/code-security/secret-scanning/configuring-secret-scanning-for-your-repositories" #Help the user to troubleshoot the activity

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Please complete the instructions below:
 1. Create your own copy of this repository by using the [Use this template](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template) button.
 
 2. Create the necessary file in the repository to exclude the following files from being scanned:
-  - Any file in a `docs` directory anywhere in the repository.
-  - All `js` files in a `dist` folder at the root of the repository.
+   - Any file in a `docs` directory anywhere in the repository.
+   - All `js` files in a `dist` folder at the root of the repository.
 
 ## Useful resources
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Resources for working with exercises and GitHub Actions in general:
 
 Your exercise is graded automatically once you have completed the instructions. To see the result of your exercise, go to the **Actions** tab, and see the most recent run on the **Grading** workflow.
 
-![](https://user-images.githubusercontent.com/40564413/142004941-f683e8e5-15ff-4c63-95d2-c150321ee926.png)
-
 See [Viewing workflow run history](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/viewing-workflow-run-history) if you need assistance.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Welcome to the exclude-files-from-secret-scanning exercise!
+# Welcome to the Exclude files from secret scanning exercise!
 
-This exercise checks FILL THIS IN. It is automatically graded via a workflow once you have completed the instructions.
+This exercise checks your knowledge on excluding files from being scanned by secret scanning. It is automatically graded via a workflow once you have completed the instructions.
 
 ## About this exercise
 
@@ -10,7 +10,7 @@ A grading script exists under `.github/workflows/grading.yml`. You do not need t
 
 <!-- REQUIRED for all exercises -->
 <details><summary>:information_source: About the use of GitHub Actions in this exercise</summary>
- 
+
 > This exercise utilizes [GitHub Actions](https://docs.github.com/en/actions), which is free for public repositories and self-hosted runners, but may incur charges on private repositories. See [About billing for GitHub Actions](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions) to learn more. The use of GitHub Actions also means that it may take the grading workflow a few seconds and sometimes minutes to run.
 </details>
 
@@ -37,29 +37,32 @@ Please complete the instructions below:
 
 1. Create your own copy of this repository by using the [Use this template](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template) button.
 
-<!-- Add your steps below starting with step 2 -->
-
-**Configure secret scanning to ignore the following conditions**
-
-- Any files in a `docs` directory anywhere in the repository.
-- and `js` files in a `dist` folder at the root of the repo
+2. Create the necessary file in the repository to exclude the following files from being scanned:
+  - Any file in a `docs` directory anywhere in the repository.
+  - All `js` files in a `dist` folder at the root of the repository.
 
 ## Useful resources
 
-Use these resources specific to this exercise to help you!
+Use these to help you!
 
-<!-- - Add further resources for the learner in list form:
-- [Title](link)
- -->
+Resources specific to this exercise:
+
+- [Configuring secret scanning for your repositories](https://docs.github.com/en/code-security/secret-scanning/configuring-secret-scanning-for-your-repositories)
+- [Filter pattern cheat sheet](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)
+
+Resources for working with exercises and GitHub Actions in general:
+
+- [Creating a repository from a template]( https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template)
+- [Viewing workflow run history](https://docs.github.com/en/actions/managing-workflow-runs/viewing-workflow-run-history)
+- [Running a workflow on GitHub](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github)
+- [About billing for GitHub Actions](https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions)
+- [GitHub Actions](https://docs.github.com/en/actions)
 
 ## Seeing your result
 
-Your exercise is graded automatically once you have completed the instructions. To see the result of your exercise, go to the **Actions** tab, and see the most recent run on the **Grading** workflow. <!-- specify expected Looking Glass display_type --><!-- specific place to look -->
+Your exercise is graded automatically once you have completed the instructions. To see the result of your exercise, go to the **Actions** tab, and see the most recent run on the **Grading** workflow.
 
-<!-- Display types:
-- actions
-- issues
- -->
+![](https://user-images.githubusercontent.com/40564413/141994177-364de749-de91-4ff5-8470-c35ff9dcb0f2.png)
 
 See [Viewing workflow run history](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/viewing-workflow-run-history) if you need assistance.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Resources for working with exercises and GitHub Actions in general:
 
 Your exercise is graded automatically once you have completed the instructions. To see the result of your exercise, go to the **Actions** tab, and see the most recent run on the **Grading** workflow.
 
-![](https://user-images.githubusercontent.com/40564413/141994177-364de749-de91-4ff5-8470-c35ff9dcb0f2.png)
+![](https://user-images.githubusercontent.com/40564413/142004941-f683e8e5-15ff-4c63-95d2-c150321ee926.png)
 
 See [Viewing workflow run history](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/viewing-workflow-run-history) if you need assistance.
 


### PR DESCRIPTION
Hi @hectorsector,

Added the instructions for this exercise.

A couple of things:

- I have made instruction 2 more precise ("Create the necessary file") than what Matt had originally written ("Configure secret scanning") to avoid having the learner trying to enable secret scanning on the repository (or see if it is enabled) which would normally be the first step to take before doing anything. I thought it's either giving away that the learner has to create a file or mentioning somewhere that the learner does not need to enable secret scanning for this exercise, thoughts on this?
- I wanted to take a screenshot of the troubleshooting workflow message but it seems it's not returning anything, is that normal?
- I got this email as soon as I made a copy of the exercise and after I finished it:
![Screenshot 2021-11-16 at 14 50 25](https://user-images.githubusercontent.com/40564413/141997585-19a0ecc8-c3cf-42ec-8cfb-4d410ce85ee3.png)
Where is this coming from? Should the learner be receiving these?